### PR TITLE
Expand hash table when it is half-filled

### DIFF
--- a/src/dawgdic/dawg-builder.h
+++ b/src/dawgdic/dawg-builder.h
@@ -205,7 +205,7 @@ class DawgBuilder {
       BaseType unfixed_index = unfixed_units_.top();
       unfixed_units_.pop();
 
-      if (num_of_states_ >= hash_table_.size() - (hash_table_.size() >> 2)) {
+      if (num_of_states_ >= hash_table_.size() - (hash_table_.size() >> 1)) {
         ExpandHashTable();
       }
 


### PR DESCRIPTION
Closes #4. 

Instead of resizing `hash_table_` when it's filled by 75%, do that when it's filled only by 50%.
That way `expandDictionary` would be called a bit more frequently but that particular infinite loop will go away. Tested on lexicon attached to #4.

Test results are available here:
[lexicon-100-result.txt](https://github.com/user-attachments/files/21603777/lexicon-100-result.txt)

