### PR TITLE
Add link to ported library in Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ DAWG はトライ（Trie）の共通部分木を併合したグラフ構造で�
   - [Interface](doc/ja/Interface.md): クラスのインタフェースに関するドキュメントです．
 - Related projects
   - Python ラッパーです．(https://github.com/kmike/DAWG)
-
+  - Haskell 移植されたライブラリ (https://github.com/swamp-agr/dawgdic)


### PR DESCRIPTION
Hello Susumu Yata,

I have spent a few months last year trying to understand this library while porting it from C++ to Haskell. I have written a blog post about the porting experience: https://an-pro.org/posts/14-porting-dawg-dictionaries.html

My main motivation was Python wrapper which I was trying to bring into a Haskell land to be able to fight with the spam.

Last month I ported a remainder, Ranked Completers, and ensured binary compatibility with your work.

With this pull request I want to connect the dots. I have used Google to translate "ported library" to Japanese. Apologies if the translation is incorrect. 

If you think this line is not necessary, please discard and close this pull request.

Many thanks and all the best,
Andrey  